### PR TITLE
fix(#183): prevent re-initialization takeover of master property registry

### DIFF
--- a/contracts/leaseflow_contracts/src/lib.rs
+++ b/contracts/leaseflow_contracts/src/lib.rs
@@ -1071,6 +1071,16 @@ impl LeaseContract {
             .temporary()
             .remove(&DataKey::NonReentrant);
     pub fn initialize(env: Env, admin: Address) {
+        // Prevent re-initialization: once an admin is set the contract is
+        // considered initialised and any subsequent call is rejected.
+        // Without this guard any account could call initialize after deployment
+        // and take over the master property registry.
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("AlreadyInitialized");
+        }
+        // Require the designated admin to co-sign so the deployer cannot
+        // silently assign an arbitrary address as admin.
+        admin.require_auth();
         env.storage()
             .instance()
             .set(&DataKey::Admin, &admin);

--- a/contracts/leaseflow_contracts/src/test.rs
+++ b/contracts/leaseflow_contracts/src/test.rs
@@ -451,6 +451,43 @@ fn test_signature_timestamp_validation() {
     assert_eq!(result_old, Err(Ok(LeaseError::InvalidSignature)));
 }
 
+// ============================================================================
+// Issue #183: Secure contract initialization
+// ============================================================================
+
+/// A second call to `initialize` must be rejected so an attacker cannot
+/// overwrite the admin and take over the master property registry.
+#[test]
+fn test_initialize_cannot_be_called_twice() {
+    let env = make_env();
+    let (_, client) = setup(&env);
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    // First call succeeds.
+    client.initialize(&admin);
+
+    // Second call — even with a different address — must panic.
+    let result = std::panic::catch_unwind(|| {
+        client.initialize(&attacker);
+    });
+    assert!(result.is_err(), "re-initialization must be rejected");
+}
+
+/// `initialize` must require the admin's own signature so the deployer cannot
+/// silently assign an arbitrary address as admin.
+#[test]
+fn test_initialize_requires_admin_auth() {
+    let env = Env::default(); // no mock_all_auths
+    let contract_id = env.register(LeaseContract, ());
+    let client = LeaseContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    // Without the admin's auth the call must fail.
+    let result = client.try_initialize(&admin);
+    assert!(result.is_err(), "initialize without admin auth must fail");
+}
+
 #[test]
 fn test_stablecoin_enforcement() {
     let env = make_env();


### PR DESCRIPTION
Closes #183

## Vulnerability

`initialize()` had **no idempotency guard** and **no auth check**:

```rust
// BEFORE — anyone can call this at any time
pub fn initialize(env: Env, admin: Address) {
    env.storage().instance().set(&DataKey::Admin, &admin);
}
```

An attacker could call `initialize` after deployment with their own address, overwriting the stored admin and gaining full control over:
- Oracle whitelisting (`whitelist_oracle`, `remove_oracle`)
- Asset allowlists (`add_allowed_asset`)
- Contract upgrades (`upgrade`)
- Platform fee configuration (`set_platform_fee`)
- KYC provider (`set_kyc_provider`)
- The entire master property registry

## Fix

Two lines added to `initialize`:

```rust
// AFTER
pub fn initialize(env: Env, admin: Address) {
    if env.storage().instance().has(&DataKey::Admin) {
        panic!("AlreadyInitialized");   // idempotency guard
    }
    admin.require_auth();               // deployer must co-sign
    env.storage().instance().set(&DataKey::Admin, &admin);
}
```

1. **Idempotency guard** — rejects any call once an admin is already stored. Matches the pattern already used in `set_admin` and `EscrowVault::initialize`.
2. **`admin.require_auth()`** — the designated admin must co-sign, preventing the deployer from silently assigning an arbitrary address.

## Tests

- `test_initialize_cannot_be_called_twice` — second call panics
- `test_initialize_requires_admin_auth` — call without admin signature fails