### PR TITLE
#175 Optimize TTL bumping strategy for active leases

### DIFF
--- a/contracts/leaseflow_contracts/src/lib.rs
+++ b/contracts/leaseflow_contracts/src/lib.rs
@@ -1825,9 +1825,11 @@ impl LeaseContract {
     }
 
     pub fn extend_ttl(env: Env, _lease_id: Symbol) {
+        // Optimized: Only bump if less than 1 week remains, reducing write fees
+        const WEEK_IN_LEDGERS: u32 = 120_960; 
         env.storage()
             .instance()
-            .extend_ttl(MONTH_IN_LEDGERS, YEAR_IN_LEDGERS);
+            .extend_ttl(WEEK_IN_LEDGERS, YEAR_IN_LEDGERS);
     }
 
     pub fn check_usage_rights(


### PR DESCRIPTION
### Description
This PR optimizes the TTL (Time-To-Live) bumping strategy within the `extend_ttl` function to reduce unnecessary ledger footprint writes and lower transaction costs.

### Changes
- Updated the `extend_ttl` threshold from `MONTH_IN_LEDGERS` to `WEEK_IN_LEDGERS` (120,960 ledgers).
- This ensures the contract only performs a state write when the lease is actually nearing expiration (within 1 week) rather than bumping it every time it falls below a month.

Closes #175
